### PR TITLE
bug iterating through formatters in the fixUrl directive

### DIFF
--- a/autofields.js
+++ b/autofields.js
@@ -346,9 +346,9 @@ angular.module('autofields.standard',['autofields.core'])
 				var render = function () {
 					var viewValue = ngModel.$modelValue;
 					if (viewValue == null) return;
-					for (var i = 0; i < ngModel.$formatters.length; i++) {
-						viewValue = ngModel.$formatters[i](viewValue);
-					}
+					angular.forEach(ngModel.$formatters, function (formatter) {
+						viewValue = formatter(viewValue);
+					})
 					ngModel.$viewValue = viewValue;
 					ngModel.$render();
 				};


### PR DESCRIPTION
For some reason

```
for (var i in ngModel.$formatters) {
    viewValue = ngModel.$formatters[i](viewValue);
}
```

in the render function in the fixUrl directive putting the formatter's function as a string instead of the formatted value
