### PR TITLE
Validation messages work for unusual properties.

### DIFF
--- a/autofields.js
+++ b/autofields.js
@@ -428,7 +428,8 @@ angular.module('autofields.validation', ['autofields.core'])
 						field.attr['ng'+helper.CamelToTitle(error)] != null)
 					)
 				){
-					fieldElements.msgs.push('('+directive.formStr+'.'+field.property+'.$error.'+error+'? \''+message+'\' : \'\')');
+					var $property_clean  = field.property.replace(/\[|\]|\./g, '');
+          				fieldElements.msgs.push('('+directive.formStr+'.'+$property_clean+'.$error.'+error+'? \''+message+'\' : \'\')');
 				}
 			});
 			// Get Valid Message


### PR DESCRIPTION
Changed validation to user `$property_clean` instead of simply `field.property`, which means it will now work if you have properties with `[`, `]`, or `.` in them.

There's probably a better way to get at the value of `$property_clean` than what I'm doing. (Currently just re-creating it).