### PR TITLE
Updated package name for angular-ui-bootsrap

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "angular": "*",
-        "angular-ui-bootstrap": "*"
+        "angular-bootstrap": "*"
     },
     "devDependencies": {}
 }


### PR DESCRIPTION
The bower package name for "angular-ui-bootstrap" is "angular-bootstrap", which includes the compiled version of js files to be used in other projects. There also exists a bower package named "angular-ui-bootstrap" unfortunately, that resolves to the original source project for "angular-ui-bootstrap", and cannot be used without separately building the compiled versions.